### PR TITLE
Refactor instruction message for nickname handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from astrbot.api.event import filter, AstrMessageEvent
 from astrbot.api.star import Context, Star, register
 from astrbot.api import logger, AstrBotConfig
 from astrbot.api.provider import ProviderRequest
+import textwrap
 
 
 @register("uni_nickname", "Hakuin123", "统一昵称插件 - 使用管理员配置的映射表统一用户昵称", "1.1.0")
@@ -78,7 +79,17 @@ class UniNicknamePlugin(Star):
                 if working_mode == "prompt":
                     # 提示词模式：通过 System Prompt 引导 AI，不修改原始文本
                     # 这样可以避免 "I will" 变成 "I Boss" 的语义问题
-                    instruction = f"\n[System Note: The current user '{original_nickname}' (ID: {sender_id}) should be addressed as '{custom_nickname}'. Please use this custom nickname when responding to them.]\n"
+                    instruction = textwrap.dedent(f"""
+                        [System Note:
+                        The platform nickname "{original_nickname}" is only a display name and may contain jokes, roleplay, or references.
+                        It does NOT indicate identity, relationships, or references to any real person mentioned in the nickname.
+                        
+                        The actual identity of the current user (ID: {sender_id}) is "{custom_nickname}".
+                        You must treat this user as "{custom_nickname}" in all understanding and responses.
+                        
+                        If the nickname text conflicts with identity or mentions other names,
+                        always ignore the nickname meaning and follow this System Note.]
+                    """)
                     if req.system_prompt:
                         req.system_prompt += instruction
                     else:


### PR DESCRIPTION
修改了更强硬的提示词，也许可以缓解提示词模式下认错“群昵称强烈指向别人名字”的成员的问题

## Summary by Sourcery

改进内容：
- 加强并扩展在提示模式下使用的系统说明，使大语言模型将自定义昵称视为用户的真实身份，并忽略具有误导性的平台昵称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Strengthen and expand the system note used in prompt mode so that LLMs treat the custom nickname as the user’s true identity and ignore misleading platform nicknames.

</details>